### PR TITLE
new email subject for new machine names

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
     Pony.mail(
       :to => Region.find_by_name('portland').users.collect {|u| u.email},
       :from => 'admin@pinballmap.com',
-      :subject => "PBM - Someone entered a new machine name",
+      :subject => "PBM - New machine name",
       :body => [machine.name, location.name, location.region.name, "(entered via #{request.user_agent})"].join("\n")
     )
   end

--- a/spec/controllers/location_machine_xrefs_controller_spec.rb
+++ b/spec/controllers/location_machine_xrefs_controller_spec.rb
@@ -14,7 +14,7 @@ describe LocationMachineXrefsController do
         mail.should == {
           :to => ["foo@bar.com"],
           :from =>"admin@pinballmap.com",
-          :subject => "PBM - Someone entered a new machine name",
+          :subject => "PBM - New machine name",
           :body => "foo\nTest Location Name\nportland\n(entered via #{request.user_agent})",
         }
       end

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -19,7 +19,7 @@ describe LocationsController do
         mail.should == {
           :to => ["foo@bar.com"],
           :from =>"admin@pinballmap.com",
-          :subject => "PBM - Someone entered a new machine name",
+          :subject => "PBM - New machine name",
           :body => "foo\nTest Location Name\nportland\n(entered via #{request.user_agent})",
         }
       end


### PR DESCRIPTION
In the notification bar on my phone, I'm not able to tell if the email is for a condition comment or a new machine name (because both subjects begin with the same text, and then it gets cut off before I can see the difference). So I updated the subject.
