### PR TITLE
show header menu in mobile

### DIFF
--- a/app/assets/stylesheets/mobile-application.css.erb
+++ b/app/assets/stylesheets/mobile-application.css.erb
@@ -21,6 +21,7 @@
 }
 
 #header ul {
+  display: inline-block;
   margin: 5px auto;
   float: none;
   width: 100%;


### PR DESCRIPTION
I mistakenly hid the header menu in mobile, when I meant to just hide it on the full size site (when the window is small). Fixed.
