### PR TITLE
fresh google analytics tracking code

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,16 +23,14 @@
 
       = yield
       :javascript
-        var _gaq = _gaq || [];
-        _gaq.push(['_setAccount', UA-33321299-1']);
-        _gaq.push(['_trackPageview']);
-        (function() {
-          var ga = document.createElement('script');
-          ga.type = 'text/javascript'; ga.async = true;
-          ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-        })();
-      
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', 'UA-33321299-1', 'pinballmap.com');
+        ga('send', 'pageview');
+
         $(function () {
           hs.registerOverlay({
             html: '<div class="closebutton" onclick="return hs.close(this)" title="Close"></div>',
@@ -43,5 +41,4 @@
           hs.graphicsDir = '/images/highslide/graphics/';
           hs.wrapperClassName = 'borderless';
 
-          #{analytics_js}
         });


### PR DESCRIPTION
Okay, I used an analytics debugger that's in chrome. The live site right now is seeing an error. My localhost was not (with this update). First, I removed the call to the helper (that helper was preventing localhost hits from being tracked).  Next, I tried two different versions of the tracking - one is the old way we used to do it, and the other is the latest suggestion by GA.

Here are the results in the debugger. https://gist.github.com/RyanTG/3e6f52935c94a30d65c7
The first is the new tracker, and below that is the old tracker.  This is not easy to read, especially because many of the lines end with "_debug.js:9" and I didn't bother to clean it up.  Anyway, I'm sharing this gist because 1) there are no errors, and 2) the OLD version seems to have more information!

I'm NOT completely confident this will work. And that's because I'm trying to track the site visitors in real-time, and it's not recording me (but this could be an issue with GA not recording localhost users very easily)... we'll see.
