### PR TITLE
update readme with new travis account

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1188,7 +1188,7 @@ DEPENDENCIES
   puma_worker_killer
   rack-attack
   rack_session_access
-  rails (= 5.2.7.1)
+  rails
   rails-controller-testing
   rails_12factor
   rails_admin

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+[![Build Status](https://app.travis-ci.com/pinballmap/pbm.svg?branch=master)](https://app.travis-ci.com/pinballmap/pbm)
 [![Coverage Status](https://coveralls.io/repos/scottwainstock/pbm/badge.png)](https://coveralls.io/r/scottwainstock/pbm)
 
 *sweet pinballin' brah*
 
-This repo is the codebase for [pinballmap.com](https://pinballmap.com). The code for the [Pinball Map mobile app is here](https://github.com/bpoore/pbm-react). If you have an app issue, please use that repo.
+This repo is the codebase for [pinballmap.com](https://pinballmap.com). The code for the [Pinball Map mobile app is here](https://github.com/pinballmap/pbm-react). If you have an app issue, please use that repo.
 
 
 ## API Documentation


### PR DESCRIPTION
The new travis account is currently not working because we've "exceeded the number of users" on this account (the number of users in unlimited, so this error doesn't make sense). But at least the badge is updated.