### PR TITLE
Use geocoded lat/lon of suggested location to determine region

### DIFF
--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -41,8 +41,6 @@ module Api
         region = nil
         if params[:region_id]
           region = Region.find(params['region_id'])
-        else
-          region = Region.near([params[:lat], params[:lon]], :effective_radius).first
         end
 
         send_new_location_notification(params, region, user)

--- a/spec/requests/api/v1/locations_controller_spec.rb
+++ b/spec/requests/api/v1/locations_controller_spec.rb
@@ -134,13 +134,13 @@ HERE
       expect(SuggestedLocation.first.zone).to eq(z)
     end
 
-    it 'searches boundary boxes by transmitted lat/lon to determine region' do
+    it 'Does not search boundary boxes by transmitted lat/lon (but instead geocodes)' do
       expect(Pony).to receive(:mail) do |mail|
         expect(mail).to include(
-          to: ['lat@guy.com'],
+          to: ['super_admin@bar.com'],
           bcc: ['super_admin@bar.com'],
           from: 'admin@pinballmap.com',
-          subject: 'PBM - New location suggested for the seattle pinball map',
+          subject: 'PBM - New location suggested for pinball map',
           body: <<HERE
     Dear Admin: You can approve this location with the click of a button at http://www.example.com/admin/suggested_location\n\nClick the "(i)" to the right, and then click the big "APPROVE LOCATION" button at the top.\n\nBut first, check that the location is not already on the map, add any missing fields (like Type, Phone, and Website), confirm the address via https://maps.google.com, and make sure it's a public venue. Thanks!!\n
 Location Name: name\n


### PR DESCRIPTION
I did this by:
- in the API, do not use user location for finding nearest region.
- In the application controller, move the geocoding up, and first use geocoded lat/lon to determine region, and if that is not available then fall back to user lat/lon

This functions on the app/api submissions as well as the regionless suggest form. I did not touch the contact form.

The API test feels like a copout, because I don't think we can geocode in Test. So I changed the test to "Does not search boundary boxes by transmitted lat/lon (but instead geocodes)" Not very cool, but I'm not sure what else to do.