### PR TITLE
add region name downcase to machine_score_xref

### DIFF
--- a/app/models/machine_score_xref.rb
+++ b/app/models/machine_score_xref.rb
@@ -12,7 +12,7 @@ class MachineScoreXref < ApplicationRecord
   })
 
   scope :region, (lambda { |name|
-    r = Region.find_by_name(name)
+    r = Region.find_by_name(name.downcase)
     joins(:location_machine_xref).joins(:location).where("
       location_machine_xrefs.id = machine_score_xrefs.location_machine_xref_id
       and locations.id = location_machine_xrefs.location_id


### PR DESCRIPTION
Bots kept hitting the machine score RSS using capitalized region names, which produced exceptions. This fixes that.