### PR TITLE
Set max_distance max limits

### DIFF
--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -138,12 +138,20 @@ module Api
       param :by_machine_id, Integer, desc: 'Machine ID to find in locations', required: false
       param :by_operator_id, Integer, desc: 'Operator ID to search by', required: false
       param :by_at_least_n_machines_type, Integer, desc: 'Only locations with N or more machines', required: false
-      param :max_distance, String, desc: 'Closest location within "max_distance" miles', required: false
+      param :max_distance, String, desc: 'Closest location within "max_distance" miles, with a max of 500', required: false
       param :no_details, Integer, desc: 'Omit data that app does not need from pull', required: false
       param :send_all_within_distance, String, desc: "Send all locations within max_distance param, or #{MAX_MILES_TO_SEARCH_FOR_CLOSEST_LOCATION} miles.", required: false
       formats ['json']
       def closest_by_lat_lon
-        max_distance = params[:max_distance] ||= MAX_MILES_TO_SEARCH_FOR_CLOSEST_LOCATION
+        if params[:max_distance].blank?
+          max_distance = MAX_MILES_TO_SEARCH_FOR_CLOSEST_LOCATION
+        elsif !params[:no_details] && params[:max_distance].to_i > 500
+          max_distance = 500
+        elsif params[:no_details] && params[:max_distance].to_i > 800
+          max_distance = 800
+        else
+          max_distance = params[:max_distance]
+        end
 
         except = params[:no_details] ? %i[country last_updated_by_user_id description region_id zone_id website phone] : nil
 
@@ -186,14 +194,22 @@ module Api
       api :GET, '/api/v1/locations/closest_by_address.json', 'Returns the closest location to transmitted address'
       description "This sends you the closest location to your address (defaults to within #{MAX_MILES_TO_SEARCH_FOR_CLOSEST_LOCATION} miles). It includes a list of machines at the location."
       param :address, String, desc: 'Address', required: true
-      param :max_distance, String, desc: 'Closest location within "max_distance" miles', required: false
+      param :max_distance, String, desc: 'Closest location within "max_distance" miles, max 500', required: false
       param :send_all_within_distance, String, desc: "Send all locations within max_distance param, or #{MAX_MILES_TO_SEARCH_FOR_CLOSEST_LOCATION} miles.", required: false
       param :no_details, Integer, desc: 'Omit data that app does not need from pull', required: false
       param :manufacturer, String, desc: 'Locations with machines from this manufacturer', required: false
       param :by_machine_group_id, String, desc: 'Machine Group to search for', required: false
       formats ['json']
       def closest_by_address
-        max_distance = params[:max_distance] ||= MAX_MILES_TO_SEARCH_FOR_CLOSEST_LOCATION
+        if params[:max_distance].blank?
+          max_distance = MAX_MILES_TO_SEARCH_FOR_CLOSEST_LOCATION
+        elsif !params[:no_details] && params[:max_distance].to_i > 500
+          max_distance = 500
+        elsif params[:no_details] && params[:max_distance].to_i > 800
+          max_distance = 800
+        else
+          max_distance = params[:max_distance]
+        end
 
         except = params[:no_details] ? %i[country last_updated_by_user_id description region_id zone_id website phone] : nil
 

--- a/app/controllers/api/v1/user_submissions_controller.rb
+++ b/app/controllers/api/v1/user_submissions_controller.rb
@@ -59,11 +59,17 @@ module Api
       api :GET, '/api/v1/user_submissions/list_within_range.json', 'Fetch user submissions within N miles of provided lat/lon'
       param :lat, String, desc: 'Latitude', required: true
       param :lon, String, desc: 'Longitude', required: true
-      param :max_distance, String, desc: 'Closest location within "max_distance" miles', required: false
+      param :max_distance, String, desc: 'Closest location within "max_distance" miles, max of 250', required: false
       param :min_date_of_submission, String, desc: 'Earliest date to consider updates from, format YYYY-MM-DD', required: false
       param :submission_type, String, desc: 'Type of submission to filter to', required: false
       def list_within_range
-        max_distance = params[:max_distance] ||= MAX_MILES_TO_SEARCH_FOR_USER_SUBMISSIONS
+        if params[:max_distance].blank?
+          max_distance = MAX_MILES_TO_SEARCH_FOR_USER_SUBMISSIONS
+        elsif params[:max_distance] > 250
+          max_distance = 250
+        else
+          max_distance = params[:max_distance]
+        end
         min_date_of_submission = params[:min_date_of_submission] ? params[:min_date_of_submission].to_date.beginning_of_day : 1.month.ago.beginning_of_day
 
         locations = apply_scopes(Location).near([params[:lat], params[:lon]], max_distance)

--- a/spec/requests/api/v1/locations_controller_spec.rb
+++ b/spec/requests/api/v1/locations_controller_spec.rb
@@ -537,6 +537,32 @@ HERE
       expect(response.body.scan('is_stern_army').size).to_not eq(0)
     end
 
+    it 'sets a max_distance limit of 500 when no_details is not used' do
+      close_location_one = FactoryBot.create(:location, region: @region, lat: 45.49, lon: -122.63)
+      close_location_two = FactoryBot.create(:location, region: @region, lat: 45.43627781006716, lon: -109.8149020864871)
+
+      get '/api/v1/locations/closest_by_address.json', params: { address: '97202', send_all_within_distance: 1, max_distance: 800 }
+
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body.size).to eq(1)
+
+      locations = parsed_body['locations']
+      expect(locations.size).to eq(1)
+    end
+
+    it 'sets a max_distance limit of 800 when no_details is used' do
+      close_location_one = FactoryBot.create(:location, region: @region, lat: 45.49, lon: -122.63)
+      close_location_two = FactoryBot.create(:location, region: @region, lat: 45.43627781006716, lon: -109.8149020864871)
+
+      get '/api/v1/locations/closest_by_address.json', params: { address: '97202', send_all_within_distance: 1, no_details: 1, max_distance: 800 }
+
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body.size).to eq(1)
+
+      locations = parsed_body['locations']
+      expect(locations.size).to eq(2)
+    end
+
     it 'respects manufacturer filter' do
       stern_closest = FactoryBot.create(:location, region: @region, name: 'Closest Stern Location', street: '123 pine', city: 'portland', phone: '503-924-9188', state: 'OR', zip: '97202', lat: 45.49, lon: -122.63)
       FactoryBot.create(:location_machine_xref, location: stern_closest, machine: FactoryBot.create(:machine, name: 'Cleo', manufacturer: 'Stern'))
@@ -624,6 +650,32 @@ HERE
       expect(response.body.scan('lon').size).to_not eq(0)
       expect(response.body.scan('city').size).to_not eq(0)
       expect(response.body.scan('is_stern_army').size).to_not eq(0)
+    end
+
+    it 'sets a max_distance limit of 500 when no_details is not used' do
+      close_location_one = FactoryBot.create(:location, region: @region, lat: 45.49, lon: -122.63)
+      close_location_two = FactoryBot.create(:location, region: @region, lat: 45.43627781006716, lon: -109.8149020864871)
+
+      get '/api/v1/locations/closest_by_address.json', params: { address: '97202', send_all_within_distance: 1, max_distance: 800 }
+
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body.size).to eq(1)
+
+      locations = parsed_body['locations']
+      expect(locations.size).to eq(1)
+    end
+
+    it 'sets a max_distance limit of 800 when no_details is used' do
+      close_location_one = FactoryBot.create(:location, region: @region, lat: 45.49, lon: -122.63)
+      close_location_two = FactoryBot.create(:location, region: @region, lat: 45.43627781006716, lon: -109.8149020864871)
+
+      get '/api/v1/locations/closest_by_address.json', params: { address: '97202', send_all_within_distance: 1, no_details: 1, max_distance: 800 }
+
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body.size).to eq(1)
+
+      locations = parsed_body['locations']
+      expect(locations.size).to eq(2)
     end
 
     it 'respects filters' do


### PR DESCRIPTION
This sets a limit to max_distance of 500 if not using "no_details" and 800 miles if using it. As usual, if not using max_distance, it defaults to the default. This commit is an attempt to set some limits on these endpoints. These may be adjusted in the future.