### PR TITLE
Add insider connected API to toggle status

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
         end
       end
       resources :location_machine_xrefs, only: [:create, :destroy, :update, :show] do
+        put :ic_toggle
         collection do
           get :top_n_machines
         end


### PR DESCRIPTION
Adds a new route `/api/v1/location_machine_xrefs/:id/ic_toggle` that will toggle the insider connected flag for a machine at a location.

Handles updating the location to reflect when a machine has one or more insider connected machines enabled. Will also set the status back to false when there are no more insider connected machines enabled.

Closes  bug #1328