### PR TITLE
Change timeout to allow the debug server to start

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,17 @@
       "args": [],
       "askParameters": false,
       "waitLaunchTime": 500
+    },
+    {
+      "type": "rdbg",
+      "name": "Run single test", // will run only the test that is under the current line
+      "request": "launch",
+      "useBundler": true,
+      "command": "rspec",
+      "script": "${file}:${lineNumber}",
+      "args": [],
+      "askParameters": false,
+      "waitLaunchTime": 500
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
       "script": "${file}",
       "args": [],
       "askParameters": false,
-      "waitLaunchTime": 10
+      "waitLaunchTime": 500
     }
   ]
 }


### PR DESCRIPTION
Increases the timeout to a more reasonable time before attaching to the debugger

Also adds a "Run single test" option which lets you only run and debug the test that is under the currently selected line.