### PR TITLE
Fix rubocop rule indention and supress warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,7 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Layout/MultilineOperationIndentation:
   Enabled: false
-Lint/HeredocIndentation:
+Layout/HeredocIndentation:
   Enabled: false
 Lint/EmptyConditionalBody:
   Enabled: false
@@ -82,6 +82,7 @@ RSpec/FactoryBot:
   Enabled: false
 
 AllCops:
+  NewCops: disable
   Exclude:
     - 'db/**/*'
     - 'config/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 require:
-- rubocop-rspec
+  - rubocop-rspec
 
 Layout/HashAlignment:
   Enabled: false


### PR DESCRIPTION
not sure if you want to run the new and unconfigured cops but they are not being run right now and just provide errors