### PR TITLE
Add an option ic_enabled parameter to the api

### DIFF
--- a/app/models/location_machine_xref.rb
+++ b/app/models/location_machine_xref.rb
@@ -113,6 +113,10 @@ class LocationMachineXref < ApplicationRecord
     UserSubmission.create(user_name: user.username, machine_name: machine.name_and_year, location_name: location.name, city_name: location.city, region_id: location.region_id, location: location, machine: machine, submission_type: UserSubmission::IC_TOGGLE_TYPE, submission: "Insider Connected toggled on #{machine.name_and_year} at #{location.name} in #{location.city} by #{user.username}", user: user)
   end
 
+  def create_ic_user_submission!(user)
+    raise ActiveRecord::RecordInvalid unless create_ic_user_submission(user)
+  end
+
   def last_updated_by_username
     user ? user.username : ''
   end

--- a/spec/requests/api/v1/location_machine_xrefs_controller_spec.rb
+++ b/spec/requests/api/v1/location_machine_xrefs_controller_spec.rb
@@ -477,6 +477,32 @@ describe Api::V1::LocationMachineXrefsController, type: :request do
       expect(location["ic_active"]).to be true
     end
 
+    it 'it should toggle via the ic_enabled param' do
+      # don't toggle with nil
+      put "/api/v1/location_machine_xrefs/#{@lmx.id}/ic_toggle.json", params: { ic_enabled: nil, user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a', HTTP_USER_AGENT: 'cleOS' }
+      get "/api/v1/location_machine_xrefs/#{@lmx.id}.json", params: { user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a', HTTP_USER_AGENT: 'cleOS' }
+      location = JSON.parse(response.body)
+      expect(location['location_machine']['ic_enabled']).to be nil
+
+      # set to false
+      put "/api/v1/location_machine_xrefs/#{@lmx.id}/ic_toggle.json", params: { ic_enabled: 'false', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a', HTTP_USER_AGENT: 'cleOS' }
+      get "/api/v1/location_machine_xrefs/#{@lmx.id}.json", params: { user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a', HTTP_USER_AGENT: 'cleOS' }
+      location = JSON.parse(response.body)
+      expect(location['location_machine']['ic_enabled']).to be false
+
+      # set to true
+      put "/api/v1/location_machine_xrefs/#{@lmx.id}/ic_toggle.json", params: { ic_enabled: 'true', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a', HTTP_USER_AGENT: 'cleOS' }
+      get "/api/v1/location_machine_xrefs/#{@lmx.id}.json", params: { user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a', HTTP_USER_AGENT: 'cleOS' }
+      location = JSON.parse(response.body)
+      expect(location['location_machine']['ic_enabled']).to be true
+
+      # set to false again
+      put "/api/v1/location_machine_xrefs/#{@lmx.id}/ic_toggle.json", params: { ic_enabled: 'false', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a', HTTP_USER_AGENT: 'cleOS' }
+      get "/api/v1/location_machine_xrefs/#{@lmx.id}.json", params: { user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a', HTTP_USER_AGENT: 'cleOS' }
+      location = JSON.parse(response.body)
+      expect(location['location_machine']['ic_enabled']).to be false
+    end
+
     it 'should not allow insider connect to be toggled when unauthed' do
       put "/api/v1/location_machine_xrefs/#{@lmx.id}/ic_toggle.json", params: { HTTP_USER_AGENT: 'cleOS' }
 


### PR DESCRIPTION
enables the use of:
/api/v1/location_machine_xref/:lmx_id/ic_enabled.json { ic_enabled: "true" }

adds a bang version of the create_ic_user_submssion that raises an exception for the transaction to work properly