### PR TITLE
Single worker debugging

### DIFF
--- a/bin/debug
+++ b/bin/debug
@@ -1,3 +1,3 @@
 #! /usr/bin/env sh
 
-bundle exec rdbg --open --nonstop bin/rails s
+WEB_CONCURRENCY=1 bundle exec rdbg --open --nonstop bin/rails s


### PR DESCRIPTION
Makes it always attach to the right process when debugging.