### PR TITLE
Headless chrome tweaks

### DIFF
--- a/.env.test.local.example
+++ b/.env.test.local.example
@@ -1,0 +1,5 @@
+# Set this to true if you want to see the chrome instance during testing
+NO_HEADLESS_CHROME=false
+
+# Use if you need a special chrome path during testing
+# CHROME_SERVICE_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ logfile
 
 /config/master.key
 .vscode/extensions.json
+/.env.test.local

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,20 @@
       "name": "Run single test", // will run only the test that is under the current line
       "request": "launch",
       "program": "bundle exec rspec ${file}:${lineNumber}",
+    },
+    {
+      "type": "ruby_lsp",
+      "name": "Run rake spec - current file with full chrome",
+      "request": "launch",
+      "env": {"NO_HEADLESS_CHROME": "true"},
+      "program": "bundle exec rspec ${file}",
+    },
+    {
+      "type": "ruby_lsp",
+      "name": "Run single test - full chrome", // will run only the test that is under the current line
+      "request": "launch",
+      "env": {"NO_HEADLESS_CHROME": "true"},
+      "program": "bundle exec rspec ${file}:${lineNumber}",
     }
   ]
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,20 +29,29 @@ RSpec.configure do |config|
     ex.run_with_retry retry: 3
   end
 
+  service = Selenium::WebDriver::Service.chrome
+  if ENV.fetch('CHROME_SERVICE_PATH', false) # rubocop:disable Style/IfUnlessModifier
+    service.executable_path = File.expand_path(ENV.fetch('CHROME_SERVICE_PATH'))
+  end
+
   Capybara.register_driver :selenium_chrome do |app|
-    Capybara::Selenium::Driver.new(app, browser: :chrome)
-  end
+    options = Selenium::WebDriver::Chrome::Options.new
+    unless ENV.fetch('NO_HEADLESS_CHROME', false)
+      options.add_argument('--headless')
+      options.add_argument('--window-size=2000,1000')
+    end
 
-  Capybara.register_driver :selenium_headless_chrome do |app|
-    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-      chromeOptions: { args: %w[headless disable-gpu window-size=2000,1000] }
+    options.add_argument('--disable-gpu')
+
+    Capybara::Selenium::Driver.new(
+      app,
+      browser: :chrome,
+      options: options,
+      service: service
     )
-
-    Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
   end
 
-  Capybara.javascript_driver = :selenium_chrome_headless
-  # Capybara.javascript_driver = :selenium_chrome
+  Capybara.javascript_driver = :selenium_chrome
 
   # == Mock Framework
   #


### PR DESCRIPTION
make chrome testing more configurable and easier to test while debugging. 