### PR TITLE
Add pagination to activity lists

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -3464,6 +3464,12 @@ color: var(--black);
     }
   }
 
+  a.gap {
+    cursor: default;
+    text-decoration: none;
+    pointer-events: none;
+  }
+
   label {
     white-space: nowrap;
     display: inline-block;

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -141,7 +141,9 @@ class LocationsController < ApplicationController
     if @record_not_found == true
       render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
     else
-      render partial: "locations/render_recent_activity", locals: { l: l }
+      user_submissions = UserSubmission.activity_feed.at_location(l)
+      @pagy, recent_activity = pagy(user_submissions, items: 10, limit_extra: false)
+      render partial: "locations/render_recent_activity", locals: { l: l, recent_activity: recent_activity, pagy: @pagy }
     end
   end
 

--- a/app/controllers/user_submissions_controller.rb
+++ b/app/controllers/user_submissions_controller.rb
@@ -4,10 +4,11 @@ class UserSubmissionsController < ApplicationController
   def list_within_range
     bounds = [ params[:boundsData][:sw][:lat], params[:boundsData][:sw][:lng],
                params[:boundsData][:ne][:lat], params[:boundsData][:ne][:lng] ]
-    user_submissions = UserSubmission.where.not(lat: nil)
-                                     .where(submission_type: %w[new_lmx remove_machine new_condition confirm_location], created_at: "2019-05-03T07:00:00.00-07:00"..Date.today.end_of_day, deleted_at: nil)
-                                     .within_bounding_box(bounds).limit(200)
-    sorted_submissions = user_submissions.order("created_at DESC")
-    render partial: "maps/nearby_activity", locals: { sorted_submissions: sorted_submissions }
+    user_submissions = UserSubmission.activity_feed
+                                     .with_coordinates
+                                     .within_bounding_box(bounds)
+                                     .limit(2000)
+    @pagy, sorted_submissions = pagy(user_submissions, items: 10, limit_extra: false)
+    render partial: "maps/nearby_activity", locals: { sorted_submissions: sorted_submissions, pagy: @pagy }
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -154,7 +154,7 @@ class Location < ApplicationRecord
   end
 
   def recent_activity
-    UserSubmission.where(submission_type: %w[new_lmx remove_machine new_condition confirm_location], location_id: self, created_at: "2019-05-03T07:00:00.00-07:00"..Date.today.end_of_day, deleted_at: nil).order("created_at DESC").limit(50)
+    UserSubmission.activity_feed.at_location(self).limit(50)
   end
 
   def former_machines

--- a/app/models/user_submission.rb
+++ b/app/models/user_submission.rb
@@ -12,6 +12,21 @@ class UserSubmission < ApplicationRecord
 
   scope :region, ->(name) { where(region_id: Region.find_by_name(name.downcase).id) }
 
+  # Activity feed scopes
+  ACTIVITY_SUBMISSION_TYPES = %w[new_lmx remove_machine new_condition confirm_location].freeze
+  ACTIVITY_START_DATE = "2019-05-03T07:00:00.00-07:00".freeze
+
+  scope :activity_feed, lambda {
+    where(
+      submission_type: ACTIVITY_SUBMISSION_TYPES,
+      created_at: ACTIVITY_START_DATE..Date.today.end_of_day,
+      deleted_at: nil
+    ).order("created_at DESC")
+  }
+
+  scope :at_location, ->(location) { where(location_id: location) }
+  scope :with_coordinates, -> { where.not(lat: nil) }
+
   NEW_LMX_TYPE = "new_lmx".freeze
   CONTACT_US_TYPE = "contact_us".freeze
   NEW_CONDITION_TYPE = "new_condition".freeze

--- a/app/views/locations/_recent_activity.html.haml
+++ b/app/views/locations/_recent_activity.html.haml
@@ -6,4 +6,20 @@
       $('#recent_location_activity_location_#{location.id}').html(loadingHTML());
       $('#recent_location_activity_location_#{location.id}').load('/locations/#{location.id}/render_recent_activity');
     });
+
+    // Handle pagination clicks with event delegation
+    $('#recent_location_activity_location_#{location.id}').on('click', '#location_activity_pagination a', function(e) {
+      e.preventDefault();
+      let href = $(this).attr('href');
+      let queryString = href.split('?')[1];
+      let url = '/locations/#{location.id}/render_recent_activity?' + queryString;
+      $('#recent_location_activity_location_#{location.id}').html(loadingHTML());
+      $('#recent_location_activity_location_#{location.id}').load(url, function() {
+        // Scroll to the top of the activity content with offset for fixed headers (220px)
+        let element = $('#recent_location_activity_location_#{location.id}')[0];
+        let elementPosition = element.getBoundingClientRect().top;
+        let offsetPosition = elementPosition + window.pageYOffset - 220;
+        window.scrollTo({ top: offsetPosition, behavior: 'instant' });
+      });
+    });
   });

--- a/app/views/locations/_render_location_detail.html.haml
+++ b/app/views/locations/_render_location_detail.html.haml
@@ -29,7 +29,7 @@
 				Location Permalink
 	%div.m_10[l, :metadata]
 		= render :partial => 'locations/render_update_metadata', :locals => {:l => l}
-	- if ENV['AWS_BUCKET_NAME'] && !is_bot?
+	- if ENV['AWS_BUCKET_NAME'].present? && !is_bot?
 		%div.location_thumbs[l, :thumbs]
 			= render :partial => 'location_picture_xrefs/show_thumbs', :locals => {:location_picture_xrefs => l.location_picture_xrefs}
 	%div.quick_buttons

--- a/app/views/locations/_render_recent_activity.html.haml
+++ b/app/views/locations/_render_recent_activity.html.haml
@@ -1,32 +1,12 @@
-%div.quick_button_content_header Recent Location Activity (max of 50)
-- l.recent_activity.take(50).each do |recent_activity|
-  %div.recent_activity_container
-    %div.recent_activity_icon
-      =image_tag("icons/#{recent_activity.submission_type}.svg", :alt => "#{recent_activity.submission_type}", :class => '')
-    %div.recent_activity_date.font14.bold #{recent_activity.created_at.strftime("%b %d, %Y")}
-    %div.recent_activity_submission.font14 
-      - if (recent_activity.submission_type == 'new_lmx')
-        %span.bold.red #{recent_activity.machine_name} 
-        added
-        - if (!recent_activity.user_name.blank?)
-          by 
-          %span.bold #{recent_activity.user_name}
-      - elsif (recent_activity.submission_type == 'new_condition')
-        %span.inline_block.mb_8 "#{recent_activity.comment}"
-        %br/
-        %span.bold.red #{recent_activity.machine_name}
-        - if (!recent_activity.user_name.blank?)
-          by 
-          %span.bold #{recent_activity.user_name}
-      - elsif (recent_activity.submission_type == 'remove_machine')
-        %span.bold.red #{recent_activity.machine_name} 
-        removed
-        - if (!recent_activity.user_name.blank?)
-          by 
-          %span.bold #{recent_activity.user_name}
-      - elsif (recent_activity.submission_type == 'confirm_location')
-        Line-up confirmed
-        - if (!recent_activity.user_name.blank?)
-          by 
-          %span.bold #{recent_activity.user_name}
-  .activity_hr
+%div.quick_button_content_header
+  - if pagy.count == 0
+    No recent location activity
+  - else
+    Showing #{pagy.from}-#{pagy.to} of #{pagy.count} recent location activit#{pagy.count == 1 ? 'y' : 'ies'}
+
+- recent_activity.each do |activity|
+  = render 'shared/activity_item', activity: activity, show_location_link: false
+
+- if pagy.pages > 1
+  #location_activity_pagination{:style => 'margin: 20px 10px'}
+    != pagy_nav(pagy)

--- a/app/views/maps/_nearby_activity.html.haml
+++ b/app/views/maps/_nearby_activity.html.haml
@@ -1,53 +1,18 @@
 %div#nearby_activity.mt_20.mb_20
   %div.bold.flex_center{:style => 'margin: 12px 0;'}
     %span.sorted_submissions
-      #{sorted_submissions.size} recent map edit(s) within current map view
+      - if pagy.count == 0
+        No recent map edits within current map view
+      - else
+        Showing #{pagy.from}-#{pagy.to} of #{pagy.count}#{pagy.count >= 2000 ? '+' : ''} recent map edit(s) within current map view
     %span.close_activity.pointer{:onclick => "closeActivity();"}
       X
   - sorted_submissions.each do |recent_activity|
-    %div.recent_activity_container
-      %div.recent_activity_icon
-        =image_tag("icons/#{recent_activity.submission_type}.svg", :alt => "#{recent_activity.submission_type}", :class => '')
-      %div.recent_activity_date.font14.bold #{recent_activity.created_at.strftime("%b %d, %Y")}
-      %div.recent_activity_submission.font14
-        - if (recent_activity.submission_type == 'new_lmx')
-          %span.bold.red #{recent_activity.machine_name}
-          added to
-          %span.bold
-            =link_to "#{recent_activity.location_name}", "/map?by_location_id=#{recent_activity.location_id}"
-          in #{recent_activity.city_name}
-          - if (!recent_activity.user_name.blank?)
-            by
-            %span.bold #{recent_activity.user_name}
-        - elsif (recent_activity.submission_type == 'new_condition')
-          - if (recent_activity.comment.blank?)
-            #{recent_activity.submission}
-          - else
-            %span.inline_block.mb_8 "#{recent_activity.comment}"
-            %br/
-            %span.bold.red #{recent_activity.machine_name}
-            %div.mt_5
-              %span.bold
-                =link_to "#{recent_activity.location_name}", "/map?by_location_id=#{recent_activity.location_id}"
-              in #{recent_activity.city_name}
-              - if (!recent_activity.user_name.blank?)
-                by
-                %span.bold #{recent_activity.user_name}
-        - elsif (recent_activity.submission_type == 'remove_machine')
-          %span.bold.red #{recent_activity.machine_name}
-          removed from
-          %span.bold
-            =link_to "#{recent_activity.location_name}", "/map?by_location_id=#{recent_activity.location_id}"
-          in #{recent_activity.city_name}
-          - if (!recent_activity.user_name.blank?)
-            by
-            %span.bold #{recent_activity.user_name}
-        - elsif (recent_activity.submission_type == 'confirm_location')
-          Line-up confirmed at
-          %span.bold
-            =link_to "#{recent_activity.location_name}", "/map?by_location_id=#{recent_activity.location_id}"
-          in #{recent_activity.city_name}
-          - if (!recent_activity.user_name.blank?)
-            by
-            %span.bold #{recent_activity.user_name}
-    .activity_hr
+    = render 'shared/activity_item', activity: recent_activity, show_location_link: true
+
+  - if pagy.pages > 1
+    #next_link{:style => 'margin: 20px 10px'}
+      != pagy_nav(pagy)
+
+:javascript
+  $(document).trigger('activity-loaded');

--- a/app/views/maps/map.html.haml
+++ b/app/views/maps/map.html.haml
@@ -248,6 +248,24 @@
     });
   });
 
+  $(document).on('activity-loaded', function() {
+    topFunction();
+  });
+
+  $("#nearby_activity_container").on("click", "#next_link > nav > a", function(e) {
+    e.preventDefault();
+    let url = new URL(e.target.href);
+    let page = url.searchParams.get("page") || "";
+
+    $('#nearby_activity_container').html(loadingHTML());
+    $.get('/user_submissions/list_within_range', {
+      boundsData: getMapBoundsData(),
+      page: page
+    }, function(data) {
+      $('#nearby_activity_container').html(data);
+    });
+  });
+
   function getMapBoundsData() {
     let bounds = map.getBounds();
     return {

--- a/app/views/shared/_activity_item.html.haml
+++ b/app/views/shared/_activity_item.html.haml
@@ -1,0 +1,53 @@
+%div.recent_activity_container
+  %div.recent_activity_icon
+    =image_tag("icons/#{activity.submission_type}.svg", :alt => "#{activity.submission_type}", :class => '')
+  %div.recent_activity_date.font14.bold #{activity.created_at.strftime("%b %d, %Y")}
+  %div.recent_activity_submission.font14
+    - if (activity.submission_type == 'new_lmx')
+      %span.bold.red #{activity.machine_name}
+      added
+      - if show_location_link
+        to
+        %span.bold
+          =link_to "#{activity.location_name}", "/map?by_location_id=#{activity.location_id}"
+        in #{activity.city_name}
+      - if (!activity.user_name.blank?)
+        by
+        %span.bold #{activity.user_name}
+    - elsif (activity.submission_type == 'new_condition')
+      - if (activity.comment.blank?)
+        #{activity.submission}
+      - else
+        %span.inline_block.mb_8 "#{activity.comment}"
+        %br/
+        %span.bold.red #{activity.machine_name}
+        - if show_location_link
+          %div.mt_5
+            %span.bold
+              =link_to "#{activity.location_name}", "/map?by_location_id=#{activity.location_id}"
+            in #{activity.city_name}
+        - if (!activity.user_name.blank?)
+          by
+          %span.bold #{activity.user_name}
+    - elsif (activity.submission_type == 'remove_machine')
+      %span.bold.red #{activity.machine_name}
+      removed
+      - if show_location_link
+        from
+        %span.bold
+          =link_to "#{activity.location_name}", "/map?by_location_id=#{activity.location_id}"
+        in #{activity.city_name}
+      - if (!activity.user_name.blank?)
+        by
+        %span.bold #{activity.user_name}
+    - elsif (activity.submission_type == 'confirm_location')
+      Line-up confirmed
+      - if show_location_link
+        at
+        %span.bold
+          =link_to "#{activity.location_name}", "/map?by_location_id=#{activity.location_id}"
+        in #{activity.city_name}
+      - if (!activity.user_name.blank?)
+        by
+        %span.bold #{activity.user_name}
+  .activity_hr


### PR DESCRIPTION
Fixes #1673.

This adds a pagination UI to "Nearby Activity" and to "Location Activity"

<img width="578" height="58" alt="image" src="https://github.com/user-attachments/assets/b982f30e-30ba-4197-a384-75ba301e3a2d" />

...

<img width="354" height="63" alt="image" src="https://github.com/user-attachments/assets/afa1c04c-81f2-4f97-87a4-440883628587" />

This PR also includes pulling out [‎app/views/shared/_activity_item.html.haml](https://github.com/pinballmap/pbm/pull/1681/files#diff-1ddd5f6adfa50643423fc7bc4a68684a7708c90b6fb3d6422afc644521ccd057) into a separate file to avoid code duplication.

A few things to consider before merging:

* The default is set to 50 per page, but you might want to adjust this
* The overall limit is set to 2000 (it'll say "2000+" when it hits the limit).  I tested it with no limit, and it is surprisingly performant!  Up to you if you want to allow users to see the full scope of the data.
* Possibly adding a `?page=` parameter to the URL bar (although this opens up quite a few routing questions that are beyond the scope of this PR)