### PR TITLE
Add filtering to nearby activity

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -2747,6 +2747,73 @@ input.score {
   text-align: left;
 }
 
+.activity_filter_dropdown {
+  margin: 12px 0;
+  padding: 0 32px;
+
+  summary {
+    cursor: pointer;
+    font-size: 14px;
+    padding: 8px;
+    user-select: none;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+}
+
+.activity_filter_option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  margin: 4px 0;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+
+  input[type="checkbox"] {
+    display: none;
+  }
+
+  .filter_icon {
+    width: 20px;
+    height: 20px;
+    opacity: 0.4;
+    transition: opacity 0.2s;
+  }
+
+  span {
+    font-size: 14px;
+  }
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  input[type="checkbox"]:checked ~ .filter_icon,
+  input[type="checkbox"]:checked + .filter_icon {
+    opacity: 1;
+  }
+
+  input[type="checkbox"]:checked ~ span {
+    font-weight: 600;
+  }
+
+  &:has(input[type="checkbox"]:checked) {
+    background-color: var(--lightpurple);
+
+    .filter_icon {
+      opacity: 1;
+    }
+
+    span {
+      font-weight: 600;
+    }
+  }
+}
+
 #activity_filter {
   display: flex;
   flex-wrap: wrap;

--- a/app/controllers/user_submissions_controller.rb
+++ b/app/controllers/user_submissions_controller.rb
@@ -4,8 +4,15 @@ class UserSubmissionsController < ApplicationController
   def list_within_range
     bounds = [ params[:boundsData][:sw][:lat], params[:boundsData][:sw][:lng],
                params[:boundsData][:ne][:lat], params[:boundsData][:ne][:lng] ]
+
+    submission_type = if params[:submission_type].present?
+                        params[:submission_type]
+    else
+                        %w[new_lmx remove_machine new_condition confirm_location]
+    end
+
     user_submissions = UserSubmission.where.not(lat: nil)
-                                     .where(submission_type: %w[new_lmx remove_machine new_condition confirm_location], created_at: "2019-05-03T07:00:00.00-07:00"..Date.today.end_of_day, deleted_at: nil)
+                                     .where(submission_type: submission_type, created_at: "2019-05-03T07:00:00.00-07:00"..Date.today.end_of_day, deleted_at: nil)
                                      .within_bounding_box(bounds)
                                      .order("created_at DESC")
                                      .limit(2000)

--- a/app/views/maps/_nearby_activity.html.haml
+++ b/app/views/maps/_nearby_activity.html.haml
@@ -7,6 +7,38 @@
         Showing #{pagy.from}-#{pagy.to} of #{pagy.count}#{pagy.count >= 2000 ? '+' : ''} recent map edit(s) within current map view
     %span.close_activity.pointer{:onclick => "closeActivity();"}
       X
+
+  %details.activity_filter_dropdown
+    %summary
+      - active_filters = []
+      - active_filters << "Machine added" if sorted_submissions.any? { |s| s.submission_type == 'new_lmx' }
+      - active_filters << "Machine removed" if sorted_submissions.any? { |s| s.submission_type == 'remove_machine' }
+      - active_filters << "Condition report" if sorted_submissions.any? { |s| s.submission_type == 'new_condition' }
+      - active_filters << "Location confirmed" if sorted_submissions.any? { |s| s.submission_type == 'confirm_location' }
+      - if active_filters.size < 4
+        Showing only #{active_filters.join(', ')}
+      - else
+        Filter activity updates
+    = form_tag user_submissions_list_within_range_path, :method => 'post', id: 'nearby_activity_filter' do
+      %label.activity_filter_option
+        =image_tag("icons/new_lmx.svg", :alt => "new_lmx", :class => 'filter_icon')
+        %input{:type => "checkbox", :name => "submission_type[]", :value => 'new_lmx', :checked => true}
+        %span Machine added
+      %label.activity_filter_option
+        =image_tag("icons/remove_machine.svg", :alt => "remove_machine", :class => 'filter_icon')
+        %input{:type => "checkbox", :name => "submission_type[]", :value => 'remove_machine', :checked => true}
+        %span Machine removed
+      %label.activity_filter_option
+        =image_tag("icons/new_condition.svg", :alt => "new_condition", :class => 'filter_icon')
+        %input{:type => "checkbox", :name => "submission_type[]", :value => 'new_condition', :checked => true}
+        %span Condition report
+      %label.activity_filter_option
+        =image_tag("icons/confirm_location.svg", :alt => "confirm_location", :class => 'filter_icon')
+        %input{:type => "checkbox", :name => "submission_type[]", :value => 'confirm_location', :checked => true}
+        %span Location confirmed
+      .flex_center
+        = submit_tag 'Apply filters', :class => "save_button", :style => "margin-top: 12px; text-transform: none; padding-left: 40px; padding-right: 40px;"
+
   - sorted_submissions.each do |recent_activity|
     %div.recent_activity_container
       %div.recent_activity_icon

--- a/app/views/maps/map.html.haml
+++ b/app/views/maps/map.html.haml
@@ -252,19 +252,70 @@
     topFunction();
   });
 
+  $(document).on('activity-loaded', function() {
+    restoreActivityFilters();
+  });
+
+  $(document).on('submit', '#nearby_activity_filter', function(e) {
+    e.preventDefault();
+    saveActivityFilters();
+    loadNearbyActivityWithFilters();
+  });
+
+  $(document).on('change', '#nearby_activity_filter input[type="checkbox"]', function() {
+    saveActivityFilters();
+  });
+
   $("#nearby_activity_container").on("click", "#next_link > nav > a", function(e) {
     e.preventDefault();
     let url = new URL(e.target.href);
     let page = url.searchParams.get("page") || "";
+    loadNearbyActivityWithFilters(page);
+  });
+
+  function saveActivityFilters() {
+    let filters = [];
+    $("#nearby_activity_container input:checkbox[name='submission_type[]']:checked").each(function () {
+      filters.push(this.value);
+    });
+    localStorage.setItem('nearbyActivityFilters', JSON.stringify(filters));
+  }
+
+  function restoreActivityFilters() {
+    let savedFilters = localStorage.getItem('nearbyActivityFilters');
+    if (savedFilters) {
+      let filters = JSON.parse(savedFilters);
+      $("#nearby_activity_container input:checkbox[name='submission_type[]']").each(function() {
+        this.checked = filters.includes(this.value);
+      });
+    }
+  }
+
+  function loadNearbyActivityWithFilters(page = "") {
+    let submissionTypes = [];
+    $("#nearby_activity_container input:checkbox[name='submission_type[]']:checked").each(function () {
+      submissionTypes.push(this.value);
+    });
+
+    let requestData = {
+      boundsData: getMapBoundsData(),
+      submission_type: submissionTypes
+    };
+
+    if (page) {
+      requestData.page = page;
+    }
 
     $('#nearby_activity_container').html(loadingHTML());
-    $.get('/user_submissions/list_within_range', {
-      boundsData: getMapBoundsData(),
-      page: page
-    }, function(data) {
-      $('#nearby_activity_container').html(data);
+    $.ajax({
+      url: '/user_submissions/list_within_range',
+      type: 'POST',
+      data: requestData,
+      success: function(data) {
+        $('#nearby_activity_container').html(data);
+      }
     });
-  });
+  }
 
   function getMapBoundsData() {
     let bounds = map.getBounds();
@@ -275,10 +326,7 @@
   }
 
   function loadNearbyActivity() {
-    $('#nearby_activity_container').html(loadingHTML());
-    $.get('/user_submissions/list_within_range', { boundsData: getMapBoundsData() }, function(data, textStatus, jqxhr) {
-      $('#nearby_activity_container').html(data);
-    });
+    loadNearbyActivityWithFilters();
   }
 
   $('#nearby_activity_button').bind('click', function(event, ui) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,7 @@ Rails.application.routes.draw do
   end
 
   get 'user_submissions/list_within_range' => 'user_submissions#list_within_range'
+  post 'user_submissions/list_within_range' => 'user_submissions#list_within_range'
 
   get 'inspire_profile' => 'pages#inspire_profile'
   get 'pages/home'


### PR DESCRIPTION
**Note**:  I recommend merging #1681 before reviewing this.

Building off of the pagination work in #1681, this PR adds the ability to filter Nearby Activity as well:

<img width="587" height="97" alt="image" src="https://github.com/user-attachments/assets/cd91ebc3-a3a9-4767-8cdc-2728d5d4b7e8" />

...

<img width="602" height="275" alt="image" src="https://github.com/user-attachments/assets/93f89609-405f-4e7f-89c2-37dc975c8da1" />

...

<img width="592" height="90" alt="image" src="https://github.com/user-attachments/assets/13482fb2-62fa-4476-a70d-2841156a0a6f" />

We may want to allow for more event types in the future (high scores, notably).